### PR TITLE
Set Plugin Until Build to Match Actual IntelliJ Version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 1.0.4
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
A new version of IntelliJ (2022.3) was released.